### PR TITLE
Clarify print to screen and fix seed averaging

### DIFF
--- a/weis/aeroelasticse/openmdao_openfast.py
+++ b/weis/aeroelasticse/openmdao_openfast.py
@@ -573,7 +573,7 @@ class FASTLoadCases(ExplicitComponent):
             self.add_output('pitch_std', val=np.zeros(self.n_ws_aep), units='deg', desc='standard deviation of pitch angles')
             self.add_output('Thrust', val=np.zeros(self.n_ws_aep), units='N', desc='rotor thrust')
             self.add_output('Thrust_std', val=np.zeros(self.n_ws_aep), units='N', desc='standard deviation of rotor thrust')
-            self.add_output('AEP', val=0.0, units='kW*h', desc='annual energy production reconstructed from the openfast simulations')
+            self.add_output('AEP', val=0.0, units='kW*h', desc='annual energy production reconstructed from the openfast simulations, only computed when multiple wind speeds are run, and only used for LCOE when the AEP DLC is set up')
 
         self.add_output('My_std',      val=0.0,            units='N*m',  desc='standard deviation of blade root flap bending moment in out-of-plane direction')
         self.add_output('flp1_std',    val=0.0,            units='deg',  desc='standard deviation of trailing-edge flap angle')
@@ -3318,8 +3318,11 @@ class FASTLoadCases(ExplicitComponent):
             return outputs
 
         if self.n_ws_aep > 0:
-            AEP, _ = self.cruncher.compute_aep("GenPwr", idx=idx_pwrcrv)
-            outputs['AEP'] = AEP
+            if self.n_ws_aep > 1:
+                AEP, _ = self.cruncher.compute_aep("GenPwr", idx=idx_pwrcrv)
+                outputs['AEP'] = AEP
+            else:
+                logger.warning('WARNING: OpenFAST is run at a single wind speed, AEP is not computed from OpenFAST. Set up the AEP DLC over multiple wind speeds to do so.')
 
             n_seeds_AEP = 0
             if len(idx_pwrcrv) > 0:
@@ -3330,9 +3333,6 @@ class FASTLoadCases(ExplicitComponent):
                 outputs['V'] = dlc_generator.cases[0].URef
                 logger.warning('WARNING: OpenFAST is not run using DLC AEP, 1.1, or 1.2. AEP cannot be estimated well. Using average power instead.')
 
-            if len(U) == 1:
-                logger.warning('WARNING: OpenFAST is run at a single wind speed. AEP cannot be estimated. Using average power instead.')
-                
             # Calculate AEP and Performance Data
             # Average across turbulent seeds for each wind speed
             def avg_seeds(vec):

--- a/weis/aeroelasticse/openmdao_openfast.py
+++ b/weis/aeroelasticse/openmdao_openfast.py
@@ -3322,25 +3322,19 @@ class FASTLoadCases(ExplicitComponent):
                 AEP, _ = self.cruncher.compute_aep("GenPwr", idx=idx_pwrcrv)
                 outputs['AEP'] = AEP
             else:
-                logger.warning('WARNING: OpenFAST is run at a single wind speed, AEP is not computed from OpenFAST. Set up the AEP DLC over multiple wind speeds to do so.')
+                logger.warning('WARNING: OpenFAST is run at a single wind speed, AEP is not computed from OpenFAST (power curve outputs are still reported). Set up the AEP DLC over multiple wind speeds to compute AEP.')
 
-            n_seeds_AEP = 0
-            if len(idx_pwrcrv) > 0:
-                sum_stats = sum_stats.iloc[idx_pwrcrv]
-                outputs['V'] = np.unique(U)
-                n_seeds_AEP = int(len(U) / len(np.unique(U)))
-            else:
-                outputs['V'] = dlc_generator.cases[0].URef
-                logger.warning('WARNING: OpenFAST is not run using DLC AEP, 1.1, or 1.2. AEP cannot be estimated well. Using average power instead.')
+            # n_ws_aep counts the same cases as idx_pwrcrv, so it is non-empty here
+            sum_stats = sum_stats.iloc[idx_pwrcrv]
+            outputs['V'] = np.unique(U)
+            n_seeds_AEP = int(len(U) / len(np.unique(U)))
 
             # Calculate AEP and Performance Data
             # Average across turbulent seeds for each wind speed
             def avg_seeds(vec):
                 vec = np.asarray(vec)
-                if n_seeds_AEP > 1:
-                    return np.array([(vec[i] + vec[i+1]) / n_seeds_AEP for i in range(0, len(vec), n_seeds_AEP)])
-                else:
-                    return vec
+                return vec.reshape(-1, n_seeds_AEP).mean(axis=1)
+            
             outputs['Cp'] = avg_seeds(sum_stats['RtFldCp']['mean'])
             outputs['Ct'] = avg_seeds(sum_stats['RtFldCt']['mean'])
             outputs['Omega'] = avg_seeds(sum_stats['RotSpeed']['mean'])

--- a/weis/glue_code/gc_LoadInputs.py
+++ b/weis/glue_code/gc_LoadInputs.py
@@ -239,6 +239,10 @@ class WindTurbineOntologyPythonWEIS(WindTurbineOntologyPython):
             DLC_label_for_AEP = '1.1'
         dlc_aep_ws = [c.URef for c in dlc_generator.cases if c.label == DLC_label_for_AEP]
         self.modeling_options['DLC_driver']['n_ws_aep'] = len(np.unique(dlc_aep_ws))
+        # OpenFAST AEP is only used if the user explicitly set up the AEP DLC over multiple wind speeds, otherwise WISDEM's AEP is used
+        self.modeling_options['DLC_driver']['use_openfast_aep'] = (
+            DLC_label_for_AEP == 'AEP' and self.modeling_options['DLC_driver']['n_ws_aep'] > 1
+        )
 
         # TMD modeling
         self.modeling_options['flags']['TMDs'] = False

--- a/weis/glue_code/gc_RunTools.py
+++ b/weis/glue_code/gc_RunTools.py
@@ -38,10 +38,13 @@ class Outputs_2_Screen(om.ExplicitComponent):
     def compute(self, inputs, outputs):
         print('########################################')
         print('Objectives')
-        print('Turbine AEP: {:<8.10f} GWh'.format(inputs['aep'][0]))
-        print('Blade Mass:  {:<8.10f} kg'.format(inputs['blade_mass'][0]))
-        print('LCOE:        {:<8.10f} USD/MWh'.format(inputs['lcoe'][0]))
-        print('Tip Defl.:   {:<8.10f} m'.format(inputs['tip_deflection'][0]))
+        # ponytail: these inputs keep their 0.0 default when glue_code leaves them unconnected (from_openfast runs, no AEP DLC), so skip the line instead of printing a meaningless zero
+        for label, name, unit in [('Turbine AEP', 'aep', 'GWh'),
+                                  ('Blade Mass', 'blade_mass', 'kg'),
+                                  ('LCOE', 'lcoe', 'USD/MWh'),
+                                  ('Tip Defl.', 'tip_deflection', 'm')]:
+            if inputs[name][0] != 0.:
+                print('{:<13}{:<8.10f} {}'.format(label + ':', inputs[name][0], unit))
         
         # OpenFAST simulation summary
         if self.options['modeling_options']['OpenFAST']['flag']:          

--- a/weis/glue_code/glue_code.py
+++ b/weis/glue_code/glue_code.py
@@ -976,8 +976,8 @@ class WindPark(om.Group):
             # Inputs to plantfinancese from wt group
             if not modeling_options["OpenFAST"]["from_openfast"]:
 
-                # Connect computed AEP only if DLC 1.1 or AEP is used, otherwise use rotorse
-                if modeling_options["DLC_driver"]["n_ws_aep"] > 0:
+                # Connect computed AEP only if the AEP DLC was run over multiple wind speeds, otherwise use rotorse
+                if modeling_options["DLC_driver"]["use_openfast_aep"]:
                     self.connect("aeroelastic.AEP", "financese_post.turbine_aep")
                 else:
                     self.connect("rotorse.rp.AEP", "financese_post.turbine_aep")
@@ -1002,8 +1002,10 @@ class WindPark(om.Group):
                 self.connect("costs.wake_loss_factor",  "financese_post.wake_loss_factor")
                 self.connect("costs.fixed_charge_rate", "financese_post.fixed_charge_rate")
 
-            if modeling_options["DLC_driver"]["n_ws_aep"] > 0:
+            if modeling_options["DLC_driver"]["use_openfast_aep"]:
                 self.connect("aeroelastic.AEP",     "outputs_2_screen_weis.aep")
+            elif modeling_options["flags"]["blade"]:
+                self.connect("rotorse.rp.AEP", "outputs_2_screen_weis.aep")
 
             # Connections to outputs to screen
             if not modeling_options["OpenFAST"]["from_openfast"]:


### PR DESCRIPTION
## Purpose
Make the reported AEP trustworthy, or absent, instead of quietly wrong.

WEIS only reconstructs a meaningful AEP from OpenFAST when the AEP DLC is set up over a range of wind speeds. The previous gate (`n_ws_aep > 0`) also accepted a plain DLC 1.1 run, even at a single wind speed, so `aeroelastic.AEP` was computed from a degenerate probability weighting and then fed to both the screen output and `financese_post`. Users running a single wind speed saw an AEP that could be confusing.

- Add a derived `DLC_driver -> use_openfast_aep` flag in `gc_LoadInputs`: true only when the AEP DLC is present *and* covers more than one wind speed. The AEP DLC is the opt-in; no new user-facing option.
- `glue_code` connects `aeroelastic.AEP` to `financese_post.turbine_aep` and the screen output only under that flag, otherwise `rotorse.rp.AEP` (WISDEM), which is the more correct value in nearly all setups.
- Do not write `outputs['AEP']` at a single wind speed; warn instead. The power curve channels (`V`, `P`, `Cp`, `Ct`, `Omega`, `pitch`, `Thrust`) are unaffected and still reported.
- `Outputs_2_Screen` skips the AEP / Blade Mass / LCOE / Tip Defl. lines when the input is unconnected (previously, `from_openfast` runs left all four at their `0.0` default and printed `0.0000000000`).
- Remove a dead branch in `get_AEP`: `idx_pwrcrv` and `n_ws_aep` come from the same DLC-label filter, so `len(idx_pwrcrv) == 0` could never be reached under `n_ws_aep > 0`.
- Fix seed averaging in `avg_seeds`, which summed only the first two seeds of each group while dividing by `n_seeds_AEP`. Correct at 2 seeds, biased low and dropping data for 3+. Now `vec.reshape(-1, n_seeds_AEP).mean(axis=1)`.

Note for reviewers: LCOE will change for setups that run DLC 1.1 without an AEP DLC, since `financese_post` now takes WISDEM's AEP. Power curve outputs with 3+ turbulent seeds will also change, as they were previously mis-averaged.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
- `pytest weis/dlc_driver/test/test_DLC_generator.py` passes 
- Built the OpenMDAO model through `final_setup()` and queried `get_source` for `outputs_2_screen_weis.aep` and `financese_post.turbine_aep` across seven DLC setups. With a 
   - WISDEM-built model (`examples/03_design_with_openfast`): AEP DLC over 2 wind speeds routes to `aeroelastic.AEP`; AEP DLC at 1 wind speed, DLC 1.1 at 2 and at 1 wind speed, and a DLC 1.3-only run all route to `rotorse.rp.AEP`. 
   - With `from_openfast: True` (`examples/05_control_optimization`): DLC 1.1 leaves the screen AEP unconnected so the line is skipped, while an AEP DLC over 2 wind speeds still routes to `aeroelastic.AEP`.
- Seed averaging verified separately on a 3-seed run, and screen-output suppression verified on a `from_openfast` run.

## Checklist

- [x] I have run existing tests which pass locally with my changes (targeted: DLC generator test plus the model-build checks above; full suite not run)
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation